### PR TITLE
Added removal of markers off screen

### DIFF
--- a/javascript/demo.js
+++ b/javascript/demo.js
@@ -173,6 +173,9 @@ function removeLine(line) {
 function filterMarkers() {
     if(map.getZoom() > station_appear_layer)
     {
+        Object.values(osm_station_layers).forEach(layer => Object.values(layer._layers).forEach(removeMarker));
+        Object.values(osm_tram_stop_layers).forEach(layer => Object.values(layer._layers).forEach(removeMarker));
+        Object.values(osm_rail_layers).forEach(layer => Object.values(layer._layers).forEach(removeLine));
         Object.values(osm_station_layers).forEach(layer => Object.values(layer._layers).forEach(filterAndAddMarker));
         Object.values(osm_tram_stop_layers).forEach(layer => Object.values(layer._layers).forEach(filterAndAddMarker));
         Object.values(osm_rail_layers).forEach(layer => Object.values(layer._layers).forEach(addLine));
@@ -185,6 +188,10 @@ function filterMarkers() {
     }
     if(map.getZoom() > signal_appear_layer)
     {
+        Object.values(osm_signal_layers).forEach(layer => Object.values(layer._layers).forEach(removeMarker));
+        Object.values(osm_buffer_stop_layers).forEach(layer => Object.values(layer._layers).forEach(removeMarker));
+        Object.values(osm_lc_layers).forEach(layer => Object.values(layer._layers).forEach(removeMarker));
+        Object.values(osm_turntable_layers).forEach(layer => Object.values(layer._layers).forEach(removeMarker));
         Object.values(osm_signal_layers).forEach(layer => Object.values(layer._layers).forEach(filterAndAddMarker));
         Object.values(osm_buffer_stop_layers).forEach(layer => Object.values(layer._layers).forEach(filterAndAddMarker));
         Object.values(osm_lc_layers).forEach(layer => Object.values(layer._layers).forEach(filterAndAddMarker));


### PR DESCRIPTION
Added a few lines to fix issue https://github.com/artemis-beta/OpenRailChart/issues/15

When the view is moved, all markers drawn on the map are removed and then redrawn in the new location, this prevents them from being retained at the same zoom level slowing the map down.